### PR TITLE
Improve keyboard mapping & add Recreated ZX Spectrum keyboard mapping

### DIFF
--- a/runtime/jsspeccy.js
+++ b/runtime/jsspeccy.js
@@ -6,7 +6,7 @@ import { DisplayHandler } from './render.js';
 import { UIController } from './ui.js';
 import { parseSNAFile, parseZ80File, parseSZXFile } from './snapshot.js';
 import { TAPFile, TZXFile } from './tape.js';
-import { KeyboardHandler } from './keyboard.js';
+import { StandardKeyboardHandler, RecreatedZXSpectrumHandler } from './keyboard.js';
 import { AudioHandler } from './audio.js';
 
 import openIcon from './icons/open.svg';
@@ -27,7 +27,10 @@ class Emulator extends EventEmitter {
         this.worker = new Worker(new URL('jsspeccy-worker.js', scriptUrl));
         this.keyboardEnabled = ('keyboardEnabled' in opts) ? opts.keyboardEnabled : true;
         if (this.keyboardEnabled) {
-            this.keyboardHandler = new KeyboardHandler(this.worker, opts.keyboardEventRoot || document);
+            console.log(opts.keyboardMap, opts)
+            this.keyboardHandler = (opts.keyboardMap == 'recreated')
+                ? new RecreatedZXSpectrumHandler(this.worker, opts.keyboardEventRoot || document)
+                : new StandardKeyboardHandler(this.worker, opts.keyboardEventRoot || document);
         }
         this.displayHandler = new DisplayHandler(this.canvas);
         this.audioHandler = new AudioHandler();
@@ -417,6 +420,7 @@ window.JSSpeccy = (container, opts) => {
         openUrl: opts.openUrl,
         tapeTrapsEnabled: ('tapeTrapsEnabled' in opts) ? opts.tapeTrapsEnabled : true,
         keyboardEnabled: keyboardEnabled,
+        keyboardMap: opts.keyboardMap || 'standard',
     });
     const ui = new UIController(container, emu, {
         zoom: opts.zoom || 1,

--- a/runtime/keyboard.js
+++ b/runtime/keyboard.js
@@ -1,4 +1,4 @@
-const SPECCY = {
+﻿const SPECCY = {
     ONE: {row: 3, mask: 0x01}, /* 1 */
     TWO: {row: 3, mask: 0x02}, /* 2 */
     THREE: {row: 3, mask: 0x04}, /* 3 */
@@ -32,7 +32,7 @@ const SPECCY = {
     L: {row: 6, mask: 0x02}, /* L */
     ENTER: {row: 6, mask: 0x01}, /* enter */
 
-    CAPS_SHIFT: {row: 0, mask: 0x01}, /* caps */
+    CAPS_SHIFT: {row: 0, mask: 0x01, isCaps: true}, /* caps */
     Z: {row: 0, mask: 0x02}, /* Z */
     X: {row: 0, mask: 0x04}, /* X */
     C: {row: 0, mask: 0x08}, /* C */
@@ -40,100 +40,100 @@ const SPECCY = {
     B: {row: 7, mask: 0x10}, /* B */
     N: {row: 7, mask: 0x08}, /* N */
     M: {row: 7, mask: 0x04}, /* M */
-    SYMBOL_SHIFT: {row: 7, mask: 0x02}, /* sym - gah, firefox screws up ctrl+key too */
+    SYMBOL_SHIFT: {row: 7, mask: 0x02, isSymbol: true}, /* sym - gah, firefox screws up ctrl+key too */
     BREAK_SPACE: {row: 7, mask: 0x01}, /* space */
 }
 
+function sym(speccyKey) {
+    return {...speccyKey, sym: true}
+}
+
+function caps(speccyKey) {
+    return {...speccyKey, caps: true}
+}
+
 const KEY_CODES = {
-    49: {row: 3, mask: 0x01}, /* 1 */
-    50: {row: 3, mask: 0x02}, /* 2 */
-    51: {row: 3, mask: 0x04}, /* 3 */
-    52: {row: 3, mask: 0x08}, /* 4 */
-    53: {row: 3, mask: 0x10}, /* 5 */
-    54: {row: 4, mask: 0x10}, /* 6 */
-    55: {row: 4, mask: 0x08}, /* 7 */
-    56: {row: 4, mask: 0x04}, /* 8 */
-    57: {row: 4, mask: 0x02}, /* 9 */
-    48: {row: 4, mask: 0x01}, /* 0 */
+    49: SPECCY.ONE,
+    50: SPECCY.TWO,
+    51: SPECCY.THREE,
+    52: SPECCY.FOUR,
+    53: SPECCY.FIVE,
+    54: SPECCY.SIX,
+    55: SPECCY.SEVEN,
+    56: SPECCY.EIGHT,
+    57: SPECCY.NINE,
+    48: SPECCY.ZERO,
 
-    81: {row: 2, mask: 0x01}, /* Q */
-    87: {row: 2, mask: 0x02}, /* W */
-    69: {row: 2, mask: 0x04}, /* E */
-    82: {row: 2, mask: 0x08}, /* R */
-    84: {row: 2, mask: 0x10}, /* T */
-    89: {row: 5, mask: 0x10}, /* Y */
-    85: {row: 5, mask: 0x08}, /* U */
-    73: {row: 5, mask: 0x04}, /* I */
-    79: {row: 5, mask: 0x02}, /* O */
-    80: {row: 5, mask: 0x01}, /* P */
+    81: SPECCY.Q,
+    87: SPECCY.W,
+    69: SPECCY.E,
+    82: SPECCY.R,
+    84: SPECCY.T,
+    89: SPECCY.Y,
+    85: SPECCY.U,
+    73: SPECCY.I,
+    79: SPECCY.O,
+    80: SPECCY.P,
 
-    65: {row: 1, mask: 0x01}, /* A */
-    83: {row: 1, mask: 0x02}, /* S */
-    68: {row: 1, mask: 0x04}, /* D */
-    70: {row: 1, mask: 0x08}, /* F */
-    71: {row: 1, mask: 0x10}, /* G */
-    72: {row: 6, mask: 0x10}, /* H */
-    74: {row: 6, mask: 0x08}, /* J */
-    75: {row: 6, mask: 0x04}, /* K */
-    76: {row: 6, mask: 0x02}, /* L */
-    13: {row: 6, mask: 0x01}, /* enter */
+    65: SPECCY.A,
+    83: SPECCY.S,
+    68: SPECCY.D,
+    70: SPECCY.F,
+    71: SPECCY.G,
+    72: SPECCY.H,
+    74: SPECCY.J,
+    75: SPECCY.K,
+    76: SPECCY.L,
+    13: SPECCY.ENTER,
 
-    16: {row: 0, mask: 0x01}, /* caps */
-    192: {row: 0, mask: 0x01}, /* backtick as caps - because firefox screws up a load of key codes when pressing shift */
-    90: {row: 0, mask: 0x02}, /* Z */
-    88: {row: 0, mask: 0x04}, /* X */
-    67: {row: 0, mask: 0x08}, /* C */
-    86: {row: 0, mask: 0x10}, /* V */
-    66: {row: 7, mask: 0x10}, /* B */
-    78: {row: 7, mask: 0x08}, /* N */
-    77: {row: 7, mask: 0x04}, /* M */
-    17: {row: 7, mask: 0x02}, /* sym - gah, firefox screws up ctrl+key too */
-    32: {row: 7, mask: 0x01}, /* space */
+    16: SPECCY.CAPS_SHIFT, /* caps */
+    192: SPECCY.CAPS_SHIFT, /* backtick as caps - because firefox screws up a load of key codes when pressing shift */
+    90: SPECCY.Z,
+    88: SPECCY.X,
+    67: SPECCY.C,
+    86: SPECCY.V,
+    66: SPECCY.B,
+    78: SPECCY.N,
+    77: SPECCY.M,
+    17: SPECCY.SYMBOL_SHIFT, /* sym - gah, firefox screws up ctrl+key too */
+    32: SPECCY.BREAK_SPACE, /* space */
 
     /* shifted combinations */
-    8: {row: 4, mask: 0x01, caps: true}, /* backspace => caps + 0 */
-    37: {row: 3, mask: 0x10, caps: true}, /* left arrow => caps + 5 */
-    38: {row: 4, mask: 0x08, caps: true}, /* up arrow => caps + 7 */
-    39: {row: 4, mask: 0x04, caps: true}, /* right arrow => caps + 8 */
-    40: {row: 4, mask: 0x10, caps: true}, /* down arrow => caps + 6 */
+    8: caps(SPECCY.ZERO), /* backspace */
+    37: caps(SPECCY.FIVE), /* left arrow */
+    38: caps(SPECCY.SEVEN), /* up arrow */
+    39: caps(SPECCY.EIGHT), /* right arrow */
+    40: caps(SPECCY.SIX), /* down arrow */
+
+    /* symbol keys */
+    '-': sym(SPECCY.J),
+    '_': sym(SPECCY.ZERO),
+    '=': sym(SPECCY.L),
+    '+': sym(SPECCY.K),
+    ';': sym(SPECCY.O),
+    ':': sym(SPECCY.Z),
+    '\'': sym(SPECCY.SEVEN),
+    '"': sym(SPECCY.P),
+    ',': sym(SPECCY.N),
+    '<': sym(SPECCY.R),
+    '.': sym(SPECCY.M),
+    '>': sym(SPECCY.T),
+    '/': sym(SPECCY.V),
+    '?': sym(SPECCY.C),
+    '*': sym(SPECCY.B),
+    '@': sym(SPECCY.TWO),
+    '#': sym(SPECCY.THREE),
 };
+KEY_CODES[String.fromCharCode(0x2264)] = sym(SPECCY.Q) // LESS_THAN_EQUAL symbol (≤)
+KEY_CODES[String.fromCharCode(0x2265)] = sym(SPECCY.E) // GREATER_THAN_EQUAL symbol (≥)
+KEY_CODES[String.fromCharCode(0x2260)] = sym(SPECCY.W) // NOT_EQUAL symbol (≠)
 
 
-export class KeyboardHandler {
+export class BaseKeyboardHandler {
     constructor(worker, rootElement) {
         this.worker = worker;
         this.rootElement = rootElement;  // where we attach keyboard event listeners
         this.eventsAreBound = false;
-
-        this.keydownHandler = (evt) => {
-            const keyCode = KEY_CODES[evt.keyCode];
-            if (keyCode) {
-                this.worker.postMessage({
-                    message: 'keyDown', row: keyCode.row, mask: keyCode.mask,
-                })
-                if (keyCode.caps) {
-                    this.worker.postMessage({
-                        message: 'keyDown', row: 0, mask: 0x01,
-                    })
-                }
-            }
-            if (!evt.metaKey) evt.preventDefault();
-        };
-
-        this.keyupHandler = (evt) => {
-            const keyCode = KEY_CODES[evt.keyCode];
-            if (keyCode) {
-                this.worker.postMessage({
-                    message: 'keyUp', row: keyCode.row, mask: keyCode.mask,
-                })
-                if (keyCode.caps) {
-                    this.worker.postMessage({
-                        message: 'keyUp', row: 0, mask: 0x01,
-                    })
-                }
-            }
-            if (!evt.metaKey) evt.preventDefault();
-        };
 
         this.keypressHandler = (evt) => {
             if (!evt.metaKey) evt.preventDefault();
@@ -161,6 +161,69 @@ export class KeyboardHandler {
             this.start();
         } else {
             this.rootElement = newRootElement;
+        }
+    }
+}
+
+export class StandardKeyboardHandler extends BaseKeyboardHandler {
+    constructor(worker, rootElement) {
+        super(worker, rootElement)
+
+        this.symbolIsShifted = false
+        this.capsIsShifted = false
+        
+        this.keydownHandler = (evt) => {
+            const keyCode = KEY_CODES[evt.keyCode] ?? KEY_CODES[evt.key];
+            if (keyCode) {
+                this.keyDown(keyCode)
+            }
+            if (!evt.metaKey) evt.preventDefault();
+        };
+
+        this.keyupHandler = (evt) => {
+            const keyCode = KEY_CODES[evt.keyCode] ?? KEY_CODES[evt.key];
+            if (keyCode) {
+                this.keyUp(keyCode)
+            }
+            if (!evt.metaKey) evt.preventDefault();
+        };
+    }
+
+    keyRaw(speccyKey, downNotUp) {
+        this.worker.postMessage({
+            message: downNotUp ? 'keyDown' : 'keyUp', row: speccyKey.row, mask: speccyKey.mask,
+        })
+    }
+
+    symbolShift(trueOrFalse) {
+        this.keyRaw(SPECCY.SYMBOL_SHIFT, trueOrFalse)
+    }
+
+    capsShift(trueOrFalse) {
+        this.keyRaw(SPECCY.CAPS_SHIFT, trueOrFalse)
+    }
+
+    keyDown(speccyKey) {
+        this.keyRaw(speccyKey, true)
+        if ('caps' in speccyKey || 'sym' in speccyKey) {
+            this.capsShift('caps' in speccyKey)
+            this.symbolShift('sym' in speccyKey)
+        } else if (speccyKey.isCaps) {
+            this.capsIsShifted = true
+        } else if (speccyKey.isSymbol) {
+            this.symbolIsShifted = true
+        }
+    }
+
+    keyUp(speccyKey) {
+        this.keyRaw(speccyKey, false)
+        if ('caps' in speccyKey || 'sym' in speccyKey) {
+            this.capsShift(this.capsIsShifted)
+            this.symbolShift(this.symbolIsShifted)
+        } else if (speccyKey.isCaps) {
+            this.capsIsShifted = false
+        } else if (speccyKey.isSymbol) {
+            this.symbolIsShifted = false
         }
     }
 }
@@ -217,12 +280,9 @@ for (const [pair, key] of Object.entries(RECREATED_SPECTRUM_GAME_LAYER)) {
     recreatedUpDown[pair.charAt(1)] = { ...key, message: "keyUp" }
 }
 
-export class RecreatedZXSpectrumHandler extends KeyboardHandler {
+export class RecreatedZXSpectrumHandler extends BaseKeyboardHandler {
     constructor(worker, rootElement) {
-        super()
-        this.worker = worker;
-        this.rootElement = rootElement;  // where we attach keyboard event listeners
-        this.eventsAreBound = false;
+        super(worker, rootElement)
 
         this.keydownHandler = (evt) => {
             const specialCode = recreatedUpDown[evt.key]
@@ -235,10 +295,6 @@ export class RecreatedZXSpectrumHandler extends KeyboardHandler {
         };
 
         this.keyupHandler = (evt) => {
-            if (!evt.metaKey) evt.preventDefault();
-        };
-
-        this.keypressHandler = (evt) => {
             if (!evt.metaKey) evt.preventDefault();
         };
     }

--- a/runtime/keyboard.js
+++ b/runtime/keyboard.js
@@ -1,3 +1,49 @@
+const SPECCY = {
+    ONE: {row: 3, mask: 0x01}, /* 1 */
+    TWO: {row: 3, mask: 0x02}, /* 2 */
+    THREE: {row: 3, mask: 0x04}, /* 3 */
+    FOUR: {row: 3, mask: 0x08}, /* 4 */
+    FIVE: {row: 3, mask: 0x10}, /* 5 */
+    SIX: {row: 4, mask: 0x10}, /* 6 */
+    SEVEN: {row: 4, mask: 0x08}, /* 7 */
+    EIGHT: {row: 4, mask: 0x04}, /* 8 */
+    NINE: {row: 4, mask: 0x02}, /* 9 */
+    ZERO: {row: 4, mask: 0x01}, /* 0 */
+
+    Q: {row: 2, mask: 0x01}, /* Q */
+    W: {row: 2, mask: 0x02}, /* W */
+    E: {row: 2, mask: 0x04}, /* E */
+    R: {row: 2, mask: 0x08}, /* R */
+    T: {row: 2, mask: 0x10}, /* T */
+    Y: {row: 5, mask: 0x10}, /* Y */
+    U: {row: 5, mask: 0x08}, /* U */
+    I: {row: 5, mask: 0x04}, /* I */
+    O: {row: 5, mask: 0x02}, /* O */
+    P: {row: 5, mask: 0x01}, /* P */
+
+    A: {row: 1, mask: 0x01}, /* A */
+    S: {row: 1, mask: 0x02}, /* S */
+    D: {row: 1, mask: 0x04}, /* D */
+    F: {row: 1, mask: 0x08}, /* F */
+    G: {row: 1, mask: 0x10}, /* G */
+    H: {row: 6, mask: 0x10}, /* H */
+    J: {row: 6, mask: 0x08}, /* J */
+    K: {row: 6, mask: 0x04}, /* K */
+    L: {row: 6, mask: 0x02}, /* L */
+    ENTER: {row: 6, mask: 0x01}, /* enter */
+
+    CAPS_SHIFT: {row: 0, mask: 0x01}, /* caps */
+    Z: {row: 0, mask: 0x02}, /* Z */
+    X: {row: 0, mask: 0x04}, /* X */
+    C: {row: 0, mask: 0x08}, /* C */
+    V: {row: 0, mask: 0x10}, /* V */
+    B: {row: 7, mask: 0x10}, /* B */
+    N: {row: 7, mask: 0x08}, /* N */
+    M: {row: 7, mask: 0x04}, /* M */
+    SYMBOL_SHIFT: {row: 7, mask: 0x02}, /* sym - gah, firefox screws up ctrl+key too */
+    BREAK_SPACE: {row: 7, mask: 0x01}, /* space */
+}
+
 const KEY_CODES = {
     49: {row: 3, mask: 0x01}, /* 1 */
     50: {row: 3, mask: 0x02}, /* 2 */
@@ -116,5 +162,84 @@ export class KeyboardHandler {
         } else {
             this.rootElement = newRootElement;
         }
+    }
+}
+
+const RECREATED_SPECTRUM_GAME_LAYER = {
+    "ab": SPECCY.ONE,
+    "cd": SPECCY.TWO,
+    "ef": SPECCY.THREE,
+    "gh": SPECCY.FOUR,
+    "ij": SPECCY.FIVE,
+    "kl": SPECCY.SIX,
+    "mn": SPECCY.SEVEN,
+    "op": SPECCY.EIGHT,
+    "qr": SPECCY.NINE,
+    "st": SPECCY.ZERO,
+
+    "uv": SPECCY.Q,
+    "wx": SPECCY.W,
+    "yz": SPECCY.E,
+    "AB": SPECCY.R,
+    "CD": SPECCY.T,
+    "EF": SPECCY.Y,
+    "GH": SPECCY.U,
+    "IJ": SPECCY.I,
+    "KL": SPECCY.O,
+    "MN": SPECCY.P,
+
+    "OP": SPECCY.A,
+    "QR": SPECCY.S,
+    "ST": SPECCY.D,
+    "UV": SPECCY.F,
+    "WX": SPECCY.G,
+    "YZ": SPECCY.H,
+    "01": SPECCY.J,
+    "23": SPECCY.K,
+    "45": SPECCY.L,
+    "67": SPECCY.ENTER,
+
+    "89": SPECCY.CAPS_SHIFT,
+    "<>": SPECCY.Z,
+    "-=": SPECCY.X,
+    "[]": SPECCY.C,
+    ";:": SPECCY.V,
+    ",.": SPECCY.B,
+    "/?": SPECCY.N,
+    "{}": SPECCY.M,
+    "!$": SPECCY.SYMBOL_SHIFT,
+    "%^": SPECCY.BREAK_SPACE,
+}
+let recreatedUpDown = {}
+
+for (const [pair, key] of Object.entries(RECREATED_SPECTRUM_GAME_LAYER)) {
+    recreatedUpDown[pair.charAt(0)] = { ...key, message: "keyDown" }
+    recreatedUpDown[pair.charAt(1)] = { ...key, message: "keyUp" }
+}
+
+export class RecreatedZXSpectrumHandler extends KeyboardHandler {
+    constructor(worker, rootElement) {
+        super()
+        this.worker = worker;
+        this.rootElement = rootElement;  // where we attach keyboard event listeners
+        this.eventsAreBound = false;
+
+        this.keydownHandler = (evt) => {
+            const specialCode = recreatedUpDown[evt.key]
+            if (specialCode) {
+                this.worker.postMessage({
+                    message: specialCode.message, row: specialCode.row, mask: specialCode.mask,
+                })
+            }
+            if (!evt.metaKey) evt.preventDefault();
+        };
+
+        this.keyupHandler = (evt) => {
+            if (!evt.metaKey) evt.preventDefault();
+        };
+
+        this.keypressHandler = (evt) => {
+            if (!evt.metaKey) evt.preventDefault();
+        };
     }
 }

--- a/runtime/keyboard.js
+++ b/runtime/keyboard.js
@@ -1,47 +1,47 @@
 ﻿const SPECCY = {
-    ONE: {row: 3, mask: 0x01}, /* 1 */
-    TWO: {row: 3, mask: 0x02}, /* 2 */
-    THREE: {row: 3, mask: 0x04}, /* 3 */
-    FOUR: {row: 3, mask: 0x08}, /* 4 */
-    FIVE: {row: 3, mask: 0x10}, /* 5 */
-    SIX: {row: 4, mask: 0x10}, /* 6 */
-    SEVEN: {row: 4, mask: 0x08}, /* 7 */
-    EIGHT: {row: 4, mask: 0x04}, /* 8 */
-    NINE: {row: 4, mask: 0x02}, /* 9 */
-    ZERO: {row: 4, mask: 0x01}, /* 0 */
+    ONE: {row: 3, mask: 0x01},
+    TWO: {row: 3, mask: 0x02},
+    THREE: {row: 3, mask: 0x04},
+    FOUR: {row: 3, mask: 0x08},
+    FIVE: {row: 3, mask: 0x10},
+    SIX: {row: 4, mask: 0x10},
+    SEVEN: {row: 4, mask: 0x08},
+    EIGHT: {row: 4, mask: 0x04},
+    NINE: {row: 4, mask: 0x02},
+    ZERO: {row: 4, mask: 0x01},
 
-    Q: {row: 2, mask: 0x01}, /* Q */
-    W: {row: 2, mask: 0x02}, /* W */
-    E: {row: 2, mask: 0x04}, /* E */
-    R: {row: 2, mask: 0x08}, /* R */
-    T: {row: 2, mask: 0x10}, /* T */
-    Y: {row: 5, mask: 0x10}, /* Y */
-    U: {row: 5, mask: 0x08}, /* U */
-    I: {row: 5, mask: 0x04}, /* I */
-    O: {row: 5, mask: 0x02}, /* O */
-    P: {row: 5, mask: 0x01}, /* P */
+    Q: {row: 2, mask: 0x01},
+    W: {row: 2, mask: 0x02},
+    E: {row: 2, mask: 0x04},
+    R: {row: 2, mask: 0x08},
+    T: {row: 2, mask: 0x10},
+    Y: {row: 5, mask: 0x10},
+    U: {row: 5, mask: 0x08},
+    I: {row: 5, mask: 0x04},
+    O: {row: 5, mask: 0x02},
+    P: {row: 5, mask: 0x01},
 
-    A: {row: 1, mask: 0x01}, /* A */
-    S: {row: 1, mask: 0x02}, /* S */
-    D: {row: 1, mask: 0x04}, /* D */
-    F: {row: 1, mask: 0x08}, /* F */
-    G: {row: 1, mask: 0x10}, /* G */
-    H: {row: 6, mask: 0x10}, /* H */
-    J: {row: 6, mask: 0x08}, /* J */
-    K: {row: 6, mask: 0x04}, /* K */
-    L: {row: 6, mask: 0x02}, /* L */
-    ENTER: {row: 6, mask: 0x01}, /* enter */
+    A: {row: 1, mask: 0x01},
+    S: {row: 1, mask: 0x02},
+    D: {row: 1, mask: 0x04},
+    F: {row: 1, mask: 0x08},
+    G: {row: 1, mask: 0x10},
+    H: {row: 6, mask: 0x10},
+    J: {row: 6, mask: 0x08},
+    K: {row: 6, mask: 0x04},
+    L: {row: 6, mask: 0x02},
+    ENTER: {row: 6, mask: 0x01},
 
-    CAPS_SHIFT: {row: 0, mask: 0x01, isCaps: true}, /* caps */
-    Z: {row: 0, mask: 0x02}, /* Z */
-    X: {row: 0, mask: 0x04}, /* X */
-    C: {row: 0, mask: 0x08}, /* C */
-    V: {row: 0, mask: 0x10}, /* V */
-    B: {row: 7, mask: 0x10}, /* B */
-    N: {row: 7, mask: 0x08}, /* N */
-    M: {row: 7, mask: 0x04}, /* M */
-    SYMBOL_SHIFT: {row: 7, mask: 0x02, isSymbol: true}, /* sym - gah, firefox screws up ctrl+key too */
-    BREAK_SPACE: {row: 7, mask: 0x01}, /* space */
+    CAPS_SHIFT: {row: 0, mask: 0x01, isCaps: true},
+    Z: {row: 0, mask: 0x02},
+    X: {row: 0, mask: 0x04},
+    C: {row: 0, mask: 0x08},
+    V: {row: 0, mask: 0x10},
+    B: {row: 7, mask: 0x10},
+    N: {row: 7, mask: 0x08},
+    M: {row: 7, mask: 0x04},
+    SYMBOL_SHIFT: {row: 7, mask: 0x02, isSymbol: true},
+    BREAK_SPACE: {row: 7, mask: 0x01},
 }
 
 function sym(speccyKey) {


### PR DESCRIPTION
# Improve keyboard mapping:
In additon to existing key mappings, map symbol keys to "symbol shift + Spectrum key", for example, map apostrope key to SYM+7.

(We take care to restore the previous shift state on the key-up event.)

# Add Recreated ZX Spectrum keyboard mapping
The [Recreated ZX Spectrum](https://recreatedzxspectrum.com/index.php) is/was a Bluetooth/USB keyboard in the form of a Spectrum. It has a "game mode" to avoid emulator key-mapping issues by emitting coded characters for each key up and down event.

Added support for that keyboard mapping, behind an `opts` option flag, `keyboardMap`.