### PR TITLE
Read the SZX halted flag from chFlags, not from past the end of the block

### DIFF
--- a/runtime/snapshot.js
+++ b/runtime/snapshot.js
@@ -282,7 +282,11 @@ export function parseSZXFile(data) {
                     'im': file.getUint8(offset + 28),
                 };
                 snapshot.tstates = file.getUint32(offset + 29, true);
-                snapshot.halted = !!(file.getUint8(offset + 37) & 0x02);
+                /* chFlags is byte 34 of the 37-byte block; byte 37 is one past
+                the end of it, and lands on the first byte of the next block's
+                ID - 'S' for SPCR, whose bit 1 is set, so every snapshot came
+                back halted. */
+                snapshot.halted = !!(file.getUint8(offset + 34) & 0x02);
                 // currently ignored:
                 // chHoldIntReqCycles, eilast, memptr
 


### PR DESCRIPTION
### The bug

`parseSZXFile` reads the halted flag like this:

```js
snapshot.halted = !!(file.getUint8(offset + 37) & 0x02);
```

`ZXSTZ80REGS` is 37 bytes and `chFlags` is byte **34**, so byte 37 is one past the end of the block. What it reads is the first byte of the *next* block's ID — in every snapshot in `static/tapeloaders/` that is the `'S'` of `SPCR`. `0x53 & 0x02` is truthy, so **every SZX snapshot is restored with the CPU marked halted**, regardless of what the file says.

The comment immediately below the line lists `chHoldIntReqCycles`, `eilast` and `memptr` as currently ignored — and `eilast` is bit 0 of `chFlags`, the same byte the halted bit lives in. So byte 34 looks like the intent, and 37 is the block length used as an offset.

### Why it matters

`halted` is consulted in exactly one place, when servicing an interrupt:

```js
if (halted) {
    // move PC on from the HALT opcode
    pc++;
    halted = 0;
}
```

That is correct when PC really is sitting on a `HALT` (which does `halted = 1; pc--`). When the flag is set spuriously, the first interrupt after the snapshot loads applies a stray `pc++` at whatever address execution has reached, putting PC one byte into the middle of an instruction.

It is timing dependent, so it does not fail uniformly — which is presumably why it has gone unnoticed.

### Reproduction

Enable **File → Auto-load tapes** and open a `.tap` on a **48K** machine. The loader snapshot takes the header block, the stray `pc++` lands somewhere fatal in the ROM's post-header processing, and `LD-BYTES` is never reached again for the program itself, so the load stops after the header.

I measured this by driving the same path `runtime/worker.js` drives — load the machine's ROMs, restore the loader snapshot through `parseSZXFile`, then run `runFrame`/`resumeFrame` servicing tape traps — against this branch's core, and counting tape traps plus checking the program reached RAM:

| machine | halted read correctly | halted forced true (current behaviour) |
|---|---|---|
| 48K | 2 traps, program loaded | **1 trap, program never loaded** |
| 128K | 2 traps, program loaded | 2 traps, program loaded |
| Pentagon | 2 traps, program loaded | 2 traps, program loaded |

### The change

One line, plus a comment recording why the offset is what it is. No snapshot files change.

I kept this PR to the fix alone so it stands on its own. We have a regression test for it in our fork, but it needs the test-suite changes from #37 to run, so it did not seem right to bundle here.