### PR TITLE
Add a run-in-background option so emulation survives tab switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Unreleased
+----------
+
+* Keep running - with audio - while the page is hidden, by handing frame
+  pacing to the emulation worker, whose timers are not throttled in
+  background tabs. Controlled by the "Run in background" File menu option
+  and the `runInBackground` constructor option (default on)
+
+
 3.2 (2024-11-23)
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The available configuration options are:
 * `machine`: specifies the machine to emulate. Can be `48` (for a 48K Spectrum), `128` (for a 128K Spectrum), or `5` (for a Pentagon 128).
 * `openUrl`: specifies a URL, or an array of URLs, to a file (or files) to load on startup, in any supported snapshot, tape or archive format. Standard browser security restrictions apply for loading remote files: if the URL being loaded is not on the same domain as the calling page, it must serve [CORS HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) to be loadable.
 * `zoom`: specifies the size of the emulator window; 1 for 100% size (one Spectrum pixel per screen pixel), 2 for 200% size and so on.
+* `runInBackground`: if true (the default), the emulator keeps running - with audio - while the page is hidden, such as in a background browser tab. Frame scheduling is handed to the emulation worker, whose timers browsers do not throttle. Set to false to pause emulation whenever the page is hidden.
 * `sandbox`: if true, all UI options for opening a new file are disabled - useful if you're showcasing a specific bit of Spectrum software on your page.
 * `tapeTrapsEnabled`: if true (the default), the emulator will recognise when the tape loading routine in the ROM is called, and load tape files instantly instead.
 * `keyboardEnabled`: True by default; if false, the emulator will not respond to keypresses.
@@ -72,6 +73,7 @@ For additional JavaScript hackery, the return value of the JSSpeccy function cal
 ```
 
 * `emu.setZoom(zoomLevel)` - set the zoom level of the emulator
+* `emu.setRunInBackground(val)` - enable or disable running while the page is hidden
 * `emu.enterFullscreen()` - activate full-screen mode
 * `emu.exitFullscreen()` - exit full-screen mode
 * `emu.toggleFullscreen()` - enter or exit full-screen mode

--- a/runtime/jsspeccy.js
+++ b/runtime/jsspeccy.js
@@ -40,12 +40,19 @@ class Emulator extends EventEmitter {
         this.tapeAutoLoadMode = opts.tapeAutoLoadMode || 'default';  // or usr0
         this.tapeIsPlaying = false;
         this.tapeTrapsEnabled = ('tapeTrapsEnabled' in opts) ? opts.tapeTrapsEnabled : true;
+        this.runInBackground = ('runInBackground' in opts) ? opts.runInBackground : true;
 
         this.msPerFrame = 20;
 
         this.isExecutingFrame = false;
         this.nextFrameTime = null;
         this.machineType = null;
+
+        this.isPacedByWorker = false;
+        this.onVisibilityChange = () => {
+            this.updatePacingMode();
+        };
+        document.addEventListener('visibilitychange', this.onVisibilityChange);
 
         this.nextFileOpenID = 0;
         this.fileOpenPromiseResolutions = {};
@@ -82,14 +89,20 @@ class Emulator extends EventEmitter {
 
                     this.displayHandler.frameCompleted(e.data.frameBuffer);
                     if (this.isRunning) {
-                        const time = performance.now();
-                        if (time > this.nextFrameTime) {
-                            /* running at full blast - start next frame but adjust time base
-                            to give it the full time allocation */
+                        if (this.isPacedByWorker) {
+                            /* the worker paces execution - keep the next
+                            frame request in flight immediately */
                             this.runFrame();
-                            this.nextFrameTime = time + this.msPerFrame;
                         } else {
-                            this.isExecutingFrame = false;
+                            const time = performance.now();
+                            if (time > this.nextFrameTime) {
+                                /* running at full blast - start next frame but adjust time base
+                                to give it the full time allocation */
+                                this.runFrame();
+                                this.nextFrameTime = time + this.msPerFrame;
+                            } else {
+                                this.isExecutingFrame = false;
+                            }
                         }
                     } else {
                         this.isExecutingFrame = false;
@@ -143,9 +156,35 @@ class Emulator extends EventEmitter {
             this.audioHandler.start();
             this.focus();
             this.emit('start');
+            this.updatePacingMode();
             window.requestAnimationFrame((t) => {
                 this.runAnimationFrame(t);
             });
+        }
+    }
+
+    /* While the page is hidden, requestAnimationFrame stops firing, so frame
+    pacing is handed to the worker, whose timers are not throttled; the main
+    thread then requests the next frame as soon as one completes. */
+    updatePacingMode() {
+        const shouldPace = document.hidden && this.isRunning && this.runInBackground;
+        if (shouldPace && !this.isPacedByWorker) {
+            this.isPacedByWorker = true;
+            this.worker.postMessage({
+                message: 'setPaced',
+                paced: true,
+                msPerFrame: this.msPerFrame,
+            });
+            if (!this.isExecutingFrame) {
+                this.runFrame();
+            }
+        } else if (!shouldPace && this.isPacedByWorker) {
+            this.isPacedByWorker = false;
+            this.worker.postMessage({
+                message: 'setPaced',
+                paced: false,
+            });
+            this.nextFrameTime = performance.now();
         }
     }
 
@@ -169,6 +208,7 @@ class Emulator extends EventEmitter {
             }
             this.audioHandler.stop();
             this.emit('pause');
+            this.updatePacingMode();
         }
     }
 
@@ -218,7 +258,7 @@ class Emulator extends EventEmitter {
             // benchmarkRenderCount++;
         }
         if (this.isRunning) {
-            if (time > this.nextFrameTime && !this.isExecutingFrame) {
+            if (!this.isPacedByWorker && time > this.nextFrameTime && !this.isExecutingFrame) {
                 this.runFrame();
                 this.nextFrameTime += this.msPerFrame;
             }
@@ -395,6 +435,7 @@ class Emulator extends EventEmitter {
 
     exit() {
         this.pause();
+        document.removeEventListener('visibilitychange', this.onVisibilityChange);
         this.worker.terminate();
     }
 }

--- a/runtime/jsspeccy.js
+++ b/runtime/jsspeccy.js
@@ -413,6 +413,11 @@ class Emulator extends EventEmitter {
         this.autoLoadTapes = val;
         this.emit('setAutoLoadTapes', val);
     }
+    setRunInBackground(val) {
+        this.runInBackground = val;
+        this.updatePacingMode();
+        this.emit('setRunInBackground', val);
+    }
     setTapeTraps(val) {
         this.tapeTrapsEnabled = val;
         this.worker.postMessage({
@@ -459,6 +464,7 @@ window.JSSpeccy = (container, opts) => {
         tapeAutoLoadMode: opts.tapeAutoLoadMode || 'default',
         openUrl: opts.openUrl,
         tapeTrapsEnabled: ('tapeTrapsEnabled' in opts) ? opts.tapeTrapsEnabled : true,
+        runInBackground: ('runInBackground' in opts) ? opts.runInBackground : true,
         keyboardEnabled: keyboardEnabled,
         keyboardMap: opts.keyboardMap || 'standard',
     });
@@ -513,6 +519,20 @@ window.JSSpeccy = (container, opts) => {
         }
         emu.on('setTapeTraps', updateTapeTrapsCheckbox);
         updateTapeTrapsCheckbox();
+
+        const runInBackgroundMenuItem = fileMenu.addItem('Run in background', () => {
+            emu.setRunInBackground(!emu.runInBackground);
+            emu.focus();
+        });
+        const updateRunInBackgroundCheckbox = () => {
+            if (emu.runInBackground) {
+                runInBackgroundMenuItem.setCheckbox();
+            } else {
+                runInBackgroundMenuItem.unsetCheckbox();
+            }
+        }
+        emu.on('setRunInBackground', updateRunInBackgroundCheckbox);
+        updateRunInBackgroundCheckbox();
 
         const machineMenu = ui.menuBar.addMenu('Machine');
         const machine48Item = machineMenu.addItem('Spectrum 48K', () => {

--- a/runtime/jsspeccy.js
+++ b/runtime/jsspeccy.js
@@ -773,6 +773,7 @@ window.JSSpeccy = (container, opts) => {
         enterFullscreen: () => {ui.enterFullscreen();},
         exitFullscreen: () => {ui.exitFullscreen();},
         setMachine: (model) => {emu.setMachine(model);},
+        setRunInBackground: (val) => {emu.setRunInBackground(val);},
         openFileDialog: () => {openFileDialog();},
         openUrl: (url) => {
             emu.openUrl(url).catch((err) => {alert(err);});

--- a/runtime/worker.js
+++ b/runtime/worker.js
@@ -12,6 +12,10 @@ let stopped = false;
 let tape = null;
 let tapeIsPlaying = false;
 
+let paced = false;
+let pacedMsPerFrame = 20;
+let nextFrameDue = 0;
+
 const loadCore = (baseUrl) => {
     WebAssembly.instantiateStreaming(
         fetch(new URL('jsspeccy-core.wasm', baseUrl), {})
@@ -113,81 +117,105 @@ const trapTapeLoad = () => {
     core.setPC(0x05e2);  /* address at which to exit the tape trap */
 }
 
+const executeFrame = (data) => {
+    if (stopped) return;
+    const frameBuffer = data.frameBuffer;
+    const frameData = new Uint8Array(frameBuffer);
+
+    let audioBufferLeft = null;
+    let audioBufferRight = null;
+    let audioLength = 0;
+    if ('audioBufferLeft' in data) {
+        audioBufferLeft = data.audioBufferLeft;
+        audioBufferRight = data.audioBufferRight;
+        audioLength = audioBufferLeft.byteLength / 4;
+        core.setAudioSamplesPerFrame(audioLength);
+    } else {
+        core.setAudioSamplesPerFrame(0);
+    }
+
+    if (tape && tapeIsPlaying) {
+        const tapePulseBufferTstateCount = core.getTapePulseBufferTstateCount();
+        const tapePulseWriteIndex = core.getTapePulseWriteIndex();
+        const [newTapePulseWriteIndex, tstatesGenerated, tapeFinished] = tape.pulseGenerator.emitPulses(
+            tapePulses, tapePulseWriteIndex, 80000 - tapePulseBufferTstateCount
+        );
+        core.setTapePulseBufferState(newTapePulseWriteIndex, tapePulseBufferTstateCount + tstatesGenerated);
+        if (tapeFinished) {
+            tapeIsPlaying = false;
+            postMessage({
+                message: 'stoppedTape',
+            });
+        }
+    }
+
+    let status = core.runFrame();
+    while (status) {
+        switch (status) {
+            case 1:
+                stopped = true;
+                throw("Unrecognised opcode!");
+            case 2:
+                trapTapeLoad();
+                break;
+            default:
+                stopped = true;
+                throw("runFrame returned unexpected result: " + status);
+        }
+
+        status = core.resumeFrame();
+    }
+
+    frameData.set(workerFrameData);
+    if (audioLength) {
+        const leftSource = new Float32Array(core.memory.buffer, core.AUDIO_BUFFER_LEFT, audioLength);
+        const rightSource = new Float32Array(core.memory.buffer, core.AUDIO_BUFFER_RIGHT, audioLength);
+        const leftData = new Float32Array(audioBufferLeft);
+        const rightData = new Float32Array(audioBufferRight);
+        leftData.set(leftSource);
+        rightData.set(rightSource);
+        postMessage({
+            message: 'frameCompleted',
+            frameBuffer,
+            audioBufferLeft,
+            audioBufferRight,
+        }, [frameBuffer, audioBufferLeft, audioBufferRight]);
+    } else {
+        postMessage({
+            message: 'frameCompleted',
+            frameBuffer,
+        }, [frameBuffer]);
+    }
+};
+
 onmessage = (e) => {
     switch (e.data.message) {
         case 'loadCore':
             loadCore(e.data.baseUrl);
             break;
         case 'runFrame':
-            if (stopped) return;
-            const frameBuffer = e.data.frameBuffer;
-            const frameData = new Uint8Array(frameBuffer);
-
-            let audioBufferLeft = null;
-            let audioBufferRight = null;
-            let audioLength = 0;
-            if ('audioBufferLeft' in e.data) {
-                audioBufferLeft = e.data.audioBufferLeft;
-                audioBufferRight = e.data.audioBufferRight;
-                audioLength = audioBufferLeft.byteLength / 4;
-                core.setAudioSamplesPerFrame(audioLength);
-            } else {
-                core.setAudioSamplesPerFrame(0);
-            }
-
-            if (tape && tapeIsPlaying) {
-                const tapePulseBufferTstateCount = core.getTapePulseBufferTstateCount();
-                const tapePulseWriteIndex = core.getTapePulseWriteIndex();
-                const [newTapePulseWriteIndex, tstatesGenerated, tapeFinished] = tape.pulseGenerator.emitPulses(
-                    tapePulses, tapePulseWriteIndex, 80000 - tapePulseBufferTstateCount
-                );
-                core.setTapePulseBufferState(newTapePulseWriteIndex, tapePulseBufferTstateCount + tstatesGenerated);
-                if (tapeFinished) {
-                    tapeIsPlaying = false;
-                    postMessage({
-                        message: 'stoppedTape',
-                    });
+            if (paced) {
+                /* while the page is hidden the main thread cannot pace
+                frames (rAF is suspended), so the worker spaces them
+                msPerFrame apart with its own timer */
+                const now = performance.now();
+                if (nextFrameDue < now - 2 * pacedMsPerFrame) {
+                    /* fallen too far behind (system sleep, long stall) -
+                    rebase rather than catching up with a burst of frames */
+                    nextFrameDue = now;
                 }
-            }
-
-            let status = core.runFrame();
-            while (status) {
-                switch (status) {
-                    case 1:
-                        stopped = true;
-                        throw("Unrecognised opcode!");
-                    case 2:
-                        trapTapeLoad();
-                        break;
-                    default:
-                        stopped = true;
-                        throw("runFrame returned unexpected result: " + status);
-                }
-
-                status = core.resumeFrame();
-            }
-
-            frameData.set(workerFrameData);
-            if (audioLength) {
-                const leftSource = new Float32Array(core.memory.buffer, core.AUDIO_BUFFER_LEFT, audioLength);
-                const rightSource = new Float32Array(core.memory.buffer, core.AUDIO_BUFFER_RIGHT, audioLength);
-                const leftData = new Float32Array(audioBufferLeft);
-                const rightData = new Float32Array(audioBufferRight);
-                leftData.set(leftSource);
-                rightData.set(rightSource);
-                postMessage({
-                    message: 'frameCompleted',
-                    frameBuffer,
-                    audioBufferLeft,
-                    audioBufferRight,
-                }, [frameBuffer, audioBufferLeft, audioBufferRight]);
+                setTimeout(() => executeFrame(e.data), Math.max(0, nextFrameDue - now));
+                nextFrameDue += pacedMsPerFrame;
             } else {
-                postMessage({
-                    message: 'frameCompleted',
-                    frameBuffer,
-                }, [frameBuffer]);
+                executeFrame(e.data);
             }
-
+            break;
+        case 'setPaced':
+            paced = e.data.paced;
+            if (paced) {
+                pacedMsPerFrame = e.data.msPerFrame;
+                nextFrameDue = performance.now();
+            }
             break;
         case 'keyDown':
             core.keyDown(e.data.row, e.data.mask);


### PR DESCRIPTION
## Problem

The frame loop is driven solely by `requestAnimationFrame` on the main thread. Browsers suspend rAF for hidden pages (background tab, minimised or fully occluded window), so the emulator freezes and audio drains to silence the moment the page is hidden.

## Approach

This adds a second frame-driving mode, switched by `visibilitychange`: while the page is hidden, the worker paces frame execution itself with its own `setTimeout` (worker timers are not throttled for hidden pages), and the main thread requests the next frame as soon as one completes (`postMessage` delivery is not throttled either). The audio path is untouched — the ring buffer keeps being fed from `frameCompleted`, and the ScriptProcessorNode keeps playing. On return to visibility the loop hands back to rAF pacing; a guard prevents the stale rAF callback from double-driving.

The worker keeps a `nextFrameDue` clock advanced 20 ms per frame, rebased when it falls more than two frames behind (system sleep etc.) so it never catches up with a burst.

## Option surface

- `runInBackground` constructor option, **default on**; documented in the README
- "Run in background" checkbox in the File menu
- `emu.setRunInBackground(val)` on the public API wrapper

Turning it off restores today's behaviour (freeze while hidden). Everything is plain runtime JS — no dependency or build changes.

## Verification

- Full test suite green on a fork carrying these exact changes (the runtime files here are byte-identical to the verified ones)
- Behavioural test in real Chrome via Playwright: with the page hidden the emulator held 50.1 fps (worker-paced) with the option on, and 0 fps with it off; 50 fps foreground before/after in both cases. One caveat from that exercise: Playwright's default launch args disable exactly the throttling under test, so the hidden state was simulated by overriding `document.hidden`/`visibilitychange` and queueing rAF callbacks, while the worker timer pacing and message chain stayed real.
- `npm run build` could not be exercised on upstream main locally (webpack-cli 4 fails to load the ESM config on current Node, independently of this change); both changed files pass an ESM syntax check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)